### PR TITLE
fix: remove LocalSchemaLoader

### DIFF
--- a/lib/open-api-mocker.js
+++ b/lib/open-api-mocker.js
@@ -6,7 +6,6 @@ const { replaceCircularObject } = require('replace-circular-object');
 const { Parser: OpenApiParser } = require('./openapi');
 const { Parser: ServersParser } = require('./servers');
 const { Parser: PathsParser } = require('./paths');
-const LocalSchemaLoader = require('./schema-loaders/local-loader');
 const OpenAPISchemaInvalid = require('./errors/openapi-schema-invalid-error');
 
 const optionsBuilder = require('./utils/options-builder');
@@ -26,8 +25,6 @@ class OpenApiMocker {
 		if(!this.schemaLoader) {
 			if(this.options.schemaLoader)
 				this.schemaLoader = this.options.schemaLoader;
-			else if(typeof schema === 'string')
-				this.schemaLoader = new LocalSchemaLoader();
 			else
 				this.schemaLoader = new ExplicitSchemaLoader();
 		}

--- a/tests/open-api-mocker.js
+++ b/tests/open-api-mocker.js
@@ -155,8 +155,8 @@ describe('OpenAPI Mocker', () => {
 				await openApiMocker.validate();
 				await openApiMocker.mock();
 
-				sinon.assert.calledOnce(LocalSchemaLoader.prototype.load);
-				sinon.assert.notCalled(ExplicitSchemaLoader.prototype.load);
+				sinon.assert.calledOnce(ExplicitSchemaLoader.prototype.load);
+				sinon.assert.notCalled(LocalSchemaLoader.prototype.load);
 			});
 		});
 


### PR DESCRIPTION
The LocalSchemaLoader class has been removed as it is no longer necessary following the changes made to SwaggerParser in commit 0391803dd865cf6e03a9c7928a343a41b898e71f. With this update, SwaggerParser.validate can handle both relative and absolute paths of the main YAML file, performing complete dereferencing and parsing.

Solves #2

